### PR TITLE
#37 - Support for Spock

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,36 @@ public class JfrTest {
 }
 ```
 
+Or with Spock Framework like this:
+```groovy
+import dev.morling.jfrunit.*
+import spock.lang.Specification
+
+import java.time.Duration
+
+import static dev.morling.jfrunit.JfrEventsAssert.*
+import static dev.morling.jfrunit.ExpectedEvent.*
+
+@JfrEventTest
+class JfrSpec extends Specification {
+
+    JfrEvents jfrEvents = new JfrEvents()
+
+    @EnableEvent('jdk.GarbageCollection')
+    @EnableEvent('jdk.ThreadSleep')
+    def 'should Have GC And Sleep Events'() {
+        when:
+        System.gc()
+        sleep(1000)
+
+        then:
+        assertThat(jfrEvents).contains(event('jdk.GarbageCollection'))
+        assertThat(jfrEvents).contains(
+                event('jdk.ThreadSleep').with('time', Duration.ofSeconds(1)))
+    }
+}
+```
+
 Note that when you're writing a test for a Quarkus application using the `@QuarkusTest` annotation, you don't need (and even should not) add the `@JfrEventTest` annotation.
 Instead, the Quarkus test framework will automatically pick up the required callbacks for managing the JFR recording.
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
       <artifactId>quarkus-junit5</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.spockframework</groupId>
+      <artifactId>spock-core</artifactId>
+      <version>1.3-groovy-2.5</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.spockframework</groupId>
+        <artifactId>spock-bom</artifactId>
+        <version>2.0-groovy-3.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -74,29 +81,13 @@
     <dependency>
       <groupId>org.spockframework</groupId>
       <artifactId>spock-core</artifactId>
-      <version>1.3-groovy-2.5</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
-      <version>2.5.14</version>
-      <type>pom</type>
-      <scope>test</scope>
+      <groupId>org.spockframework</groupId>
+      <artifactId>spock-junit4</artifactId>
+      <scope>provided</scope>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -146,10 +137,7 @@
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
-        <version>1.12.0</version>
-        <configuration>
-          <targetBytecode>11</targetBytecode>
-        </configuration>
+        <version>1.12.1</version>
 
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,27 @@
       <artifactId>spock-core</artifactId>
       <version>1.3-groovy-2.5</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.groovy</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy-all</artifactId>
+      <version>2.5.14</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -123,6 +143,35 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.12.0</version>
+        <configuration>
+          <targetBytecode>11</targetBytecode>
+        </configuration>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>compileTests</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+          <includes>
+            <include>**/*Test.java</include>
+            <include>**/*Spec.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,6 @@
         <executions>
           <execution>
             <goals>
-              <goal>compile</goal>
               <goal>compileTests</goal>
             </goals>
           </execution>

--- a/src/main/java/dev/morling/jfrunit/JfrEventTest.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEventTest.java
@@ -21,8 +21,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.spockframework.runtime.extension.ExtensionAnnotation;
 
-
+@ExtensionAnnotation(JfrEventTestSpockExtension.class)
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(JfrEventTestExtension.class)
 @Target(ElementType.TYPE)

--- a/src/main/java/dev/morling/jfrunit/JfrEventTestSpockExtension.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEventTestSpockExtension.java
@@ -27,11 +27,12 @@ import java.util.stream.Collectors;
 
 public class JfrEventTestSpockExtension extends AbstractAnnotationDrivenExtension<JfrEventTest> {
 
+    private static final JfrMethodInterceptor JFR_METHOD_INTERCEPTOR = new JfrMethodInterceptor();
+
     @Override
     public void visitSpecAnnotation(JfrEventTest annotation, SpecInfo spec) {
-        final JfrMethodInterceptor interceptor = new JfrMethodInterceptor();
         spec.getBottomSpec().getAllFeatures().stream().forEach(featureInfo -> {
-            featureInfo.getFeatureMethod().addInterceptor(interceptor);
+            featureInfo.getFeatureMethod().addInterceptor(JFR_METHOD_INTERCEPTOR);
         });
     }
 

--- a/src/main/java/dev/morling/jfrunit/JfrEventTestSpockExtension.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEventTestSpockExtension.java
@@ -1,0 +1,104 @@
+/**
+ *  Copyright 2020 - 2021 The JfrUnit authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.jfrunit;
+
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension;
+import org.spockframework.runtime.extension.AbstractMethodInterceptor;
+import org.spockframework.runtime.extension.IMethodInvocation;
+import org.spockframework.runtime.model.FieldInfo;
+import org.spockframework.runtime.model.SpecInfo;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class JfrEventTestSpockExtension extends AbstractAnnotationDrivenExtension<JfrEventTest> {
+
+    @Override
+    public void visitSpecAnnotation(JfrEventTest annotation, SpecInfo spec) {
+        final JfrMethodInterceptor interceptor = new JfrMethodInterceptor();
+        spec.getAllFeatures().stream().forEach(featureInfo -> {
+            featureInfo.getFeatureMethod().addInterceptor(interceptor);
+        });
+    }
+
+    private String getEnabledConfiguration(IMethodInvocation invocation) {
+        return Optional.ofNullable(invocation.getMethod().getAnnotation(EnableConfiguration.class))
+                .map(EnableConfiguration::value)
+                .map(String::trim)
+                .orElse(null);
+    }
+
+    private List<EventConfiguration> getEnabledEvents(IMethodInvocation invocation) {
+        return Arrays.stream(invocation.getMethod().getReflection().getAnnotationsByType(EnableEvent.class))
+                .map(e -> new EventConfiguration(e.value(), e.stackTrace(), e.threshold(), e.period()))
+                .collect(Collectors.toList());
+    }
+
+    private List<JfrEventsContext> getJfrEvents(IMethodInvocation invocation) {
+        return invocation.getSpec().getAllFields().stream()
+                .filter(fieldInfo -> JfrEvents.class.equals(fieldInfo.getType()))
+                .map(fieldInfo -> new JfrEventsContext((JfrEvents) fieldInfo.readValue(invocation.getInstance()), fieldInfo))
+                .collect(Collectors.toList());
+    }
+
+    private class JfrMethodInterceptor extends AbstractMethodInterceptor {
+
+        @Override
+        public void interceptFeatureMethod(IMethodInvocation invocation) throws Throwable {
+            String enabledConfiguration = getEnabledConfiguration(invocation);
+            List<EventConfiguration> enabledEvents = getEnabledEvents(invocation);
+
+            getJfrEvents(invocation).stream().map(JfrEventsContext::getJfrEvents).forEach(jfrEvents -> {
+                jfrEvents.startRecordingEvents(enabledConfiguration, enabledEvents, invocation.getMethod().getReflection());
+            });
+            try {
+                invocation.proceed();
+            } finally {
+                getJfrEvents(invocation).stream().forEach(jfrEventsContext -> {
+                    JfrEvents jfrEvents = jfrEventsContext.getJfrEvents();
+                    jfrEvents.stopRecordingEvents();
+                    if (!jfrEventsContext.getFieldInfo().isShared()) {
+                        jfrEvents.clear();
+                    }
+                });
+            }
+        }
+
+    }
+
+    private static class JfrEventsContext {
+
+        private final JfrEvents jfrEvents;
+
+        private final FieldInfo fieldInfo;
+
+        public JfrEventsContext(JfrEvents jfrEvents, FieldInfo fieldInfo) {
+            this.jfrEvents = jfrEvents;
+            this.fieldInfo = fieldInfo;
+        }
+
+        public JfrEvents getJfrEvents() {
+            return jfrEvents;
+        }
+
+        public FieldInfo getFieldInfo() {
+            return fieldInfo;
+        }
+    }
+
+}

--- a/src/main/java/dev/morling/jfrunit/JfrEventTestSpockExtension.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEventTestSpockExtension.java
@@ -31,32 +31,12 @@ public class JfrEventTestSpockExtension extends AbstractAnnotationDrivenExtensio
     @Override
     public void visitSpecAnnotation(JfrEventTest annotation, SpecInfo spec) {
         final JfrMethodInterceptor interceptor = new JfrMethodInterceptor();
-        spec.getAllFeatures().stream().forEach(featureInfo -> {
+        spec.getBottomSpec().getAllFeatures().stream().forEach(featureInfo -> {
             featureInfo.getFeatureMethod().addInterceptor(interceptor);
         });
     }
 
-    private String getEnabledConfiguration(IMethodInvocation invocation) {
-        return Optional.ofNullable(invocation.getMethod().getAnnotation(EnableConfiguration.class))
-                .map(EnableConfiguration::value)
-                .map(String::trim)
-                .orElse(null);
-    }
-
-    private List<EventConfiguration> getEnabledEvents(IMethodInvocation invocation) {
-        return Arrays.stream(invocation.getMethod().getReflection().getAnnotationsByType(EnableEvent.class))
-                .map(e -> new EventConfiguration(e.value(), e.stackTrace(), e.threshold(), e.period()))
-                .collect(Collectors.toList());
-    }
-
-    private List<JfrEventsContext> getJfrEvents(IMethodInvocation invocation) {
-        return invocation.getSpec().getAllFields().stream()
-                .filter(fieldInfo -> JfrEvents.class.equals(fieldInfo.getType()))
-                .map(fieldInfo -> new JfrEventsContext((JfrEvents) fieldInfo.readValue(invocation.getInstance()), fieldInfo))
-                .collect(Collectors.toList());
-    }
-
-    private class JfrMethodInterceptor extends AbstractMethodInterceptor {
+    private static class JfrMethodInterceptor extends AbstractMethodInterceptor {
 
         @Override
         public void interceptFeatureMethod(IMethodInvocation invocation) throws Throwable {
@@ -77,6 +57,26 @@ public class JfrEventTestSpockExtension extends AbstractAnnotationDrivenExtensio
                     }
                 });
             }
+        }
+
+        private String getEnabledConfiguration(IMethodInvocation invocation) {
+            return Optional.ofNullable(invocation.getMethod().getAnnotation(EnableConfiguration.class))
+                    .map(EnableConfiguration::value)
+                    .map(String::trim)
+                    .orElse(null);
+        }
+
+        private List<EventConfiguration> getEnabledEvents(IMethodInvocation invocation) {
+            return Arrays.stream(invocation.getMethod().getReflection().getAnnotationsByType(EnableEvent.class))
+                    .map(e -> new EventConfiguration(e.value(), e.stackTrace(), e.threshold(), e.period()))
+                    .collect(Collectors.toList());
+        }
+
+        private List<JfrEventsContext> getJfrEvents(IMethodInvocation invocation) {
+            return invocation.getSpec().getAllFields().stream()
+                    .filter(fieldInfo -> JfrEvents.class.equals(fieldInfo.getType()))
+                    .map(fieldInfo -> new JfrEventsContext((JfrEvents) fieldInfo.readValue(invocation.getInstance()), fieldInfo))
+                    .collect(Collectors.toList());
         }
 
     }

--- a/src/main/java/dev/morling/jfrunit/JfrEvents.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEvents.java
@@ -108,6 +108,10 @@ public class JfrEvents {
         }
     }
 
+    void clear() {
+        events.clear();
+    }
+
     /**
      * Ensures all previously emitted events have been consumed.
      */
@@ -134,14 +138,16 @@ public class JfrEvents {
     }
 
     public Stream<RecordedEvent> getEvents() {
+        awaitEvents();
         return events.stream();
     }
 
     public Stream<RecordedEvent> filter(Predicate<RecordedEvent> predicate) {
-        return events.stream().filter(predicate);
+        return stream().filter(predicate);
     }
 
     public Stream<RecordedEvent> stream() {
+        awaitEvents();
         return events.stream();
     }
 

--- a/src/main/java/dev/morling/jfrunit/JfrEventsAssert.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEventsAssert.java
@@ -30,7 +30,7 @@ public class JfrEventsAssert extends AbstractAssert<JfrEventsAssert, JfrEvents> 
     public JfrEventsAssert contains(ExpectedEvent expectedEvent) {
         isNotNull();
 
-        boolean found = actual.getEvents()
+        boolean found = actual.events()
             .anyMatch(re -> ExpectedEvent.matches(expectedEvent, re));
 
         if (!found) {

--- a/src/test/groovy/dev/morling/jfrunit/InheritedSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/InheritedSpec.groovy
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2020 - 2021 The JfrUnit authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.jfrunit
+
+import static dev.morling.jfrunit.ExpectedEvent.event
+import static dev.morling.jfrunit.JfrEventsAssert.assertThat
+
+class InheritedSpec extends ParentSpec {
+
+    @EnableEvent("jdk.GarbageCollection")
+    def 'test inherited fields'() {
+        when:
+        System.gc()
+
+        then:
+        assertThat(jfrEvents).contains(event("jdk.GarbageCollection"))
+    }
+
+}

--- a/src/test/groovy/dev/morling/jfrunit/JfrEventsSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrEventsSpec.groovy
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2020 - 2021 The JfrUnit authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.jfrunit
+
+import spock.lang.Specification
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class JfrEventsSpec extends Specification {
+
+    def 'does not block on stream() when capturing is not running'() {
+        given:
+        JfrEvents jfrEvents = new JfrEvents()
+        CountDownLatch latch = new CountDownLatch(1)
+
+        when:
+        Executors.newFixedThreadPool(1).submit({
+            jfrEvents.stream()
+            latch.countDown()
+        })
+
+        then:
+        latch.await(1, TimeUnit.SECONDS)
+    }
+
+}

--- a/src/test/groovy/dev/morling/jfrunit/JfrSpockSharedSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrSpockSharedSpec.groovy
@@ -35,7 +35,7 @@ class JfrSpockSharedSpec extends Specification {
     JfrEvents jfrEvents = new JfrEvents()
 
     @EnableEvent(value = 'jdk.FileWrite', threshold = 0L)
-    def 'should record written bytes on each iteration'(int iteration) {
+    def 'records written bytes on each iteration'(int iteration) {
         given:
         long bytesWritten = iteration * 10
         byte[] array = new byte[bytesWritten]

--- a/src/test/groovy/dev/morling/jfrunit/JfrSpockSharedSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrSpockSharedSpec.groovy
@@ -46,7 +46,7 @@ class JfrSpockSharedSpec extends Specification {
         file << array
 
         then:
-        jfrEvents.events.filter({it.eventType.name == 'jdk.FileWrite' }).count() == iteration
+        jfrEvents.events.filter{ it.eventType.name == 'jdk.FileWrite' }.count() == iteration
         JfrEventsAssert.assertThat(jfrEvents).contains(
                 ExpectedEvent.event('jdk.FileWrite')
                         .with('bytesWritten', bytesWritten)

--- a/src/test/groovy/dev/morling/jfrunit/JfrSpockSharedSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrSpockSharedSpec.groovy
@@ -17,6 +17,7 @@ package dev.morling.jfrunit
 
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Shared
 import spock.lang.Specification
 
 import java.time.Duration
@@ -25,25 +26,13 @@ import static dev.morling.jfrunit.ExpectedEvent.event
 import static dev.morling.jfrunit.JfrEventsAssert.assertThat
 
 @JfrEventTest
-class JfrSpockSpec extends Specification {
+class JfrSpockSharedSpec extends Specification {
 
     @Rule
     TemporaryFolder temporaryFolder = new TemporaryFolder()
 
+    @Shared
     JfrEvents jfrEvents = new JfrEvents()
-
-    @EnableEvent('jdk.GarbageCollection')
-    @EnableEvent('jdk.ThreadSleep')
-    def 'should Have GC And Sleep Events'() {
-        when:
-        System.gc()
-        sleep(1000)
-
-        then:
-        assertThat(jfrEvents).contains(event('jdk.GarbageCollection'))
-        assertThat(jfrEvents).contains(
-                event('jdk.ThreadSleep').with('time', Duration.ofSeconds(1)))
-    }
 
     @EnableEvent(value = 'jdk.FileWrite', threshold = 0L)
     def 'should record written bytes on each iteration'(int iteration) {
@@ -57,7 +46,7 @@ class JfrSpockSpec extends Specification {
         file << array
 
         then:
-        jfrEvents.events.filter({it.eventType.name == 'jdk.FileWrite' }).count() == 1
+        jfrEvents.events.filter({it.eventType.name == 'jdk.FileWrite' }).count() == iteration
         JfrEventsAssert.assertThat(jfrEvents).contains(
                 ExpectedEvent.event('jdk.FileWrite')
                         .with('bytesWritten', bytesWritten)

--- a/src/test/groovy/dev/morling/jfrunit/JfrSpockSharedSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrSpockSharedSpec.groovy
@@ -46,7 +46,7 @@ class JfrSpockSharedSpec extends Specification {
         file << array
 
         then:
-        jfrEvents.events.filter{ it.eventType.name == 'jdk.FileWrite' }.count() == iteration
+        jfrEvents.events().filter{ it.eventType.name == 'jdk.FileWrite' }.count() == iteration
         JfrEventsAssert.assertThat(jfrEvents).contains(
                 ExpectedEvent.event('jdk.FileWrite')
                         .with('bytesWritten', bytesWritten)

--- a/src/test/groovy/dev/morling/jfrunit/JfrSpockSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrSpockSpec.groovy
@@ -37,12 +37,12 @@ class JfrSpockSpec extends Specification {
     def 'should Have GC And Sleep Events'() {
         when:
         System.gc()
-        sleep(1000)
+        sleep(50)
 
         then:
         assertThat(jfrEvents).contains(event('jdk.GarbageCollection'))
         assertThat(jfrEvents).contains(
-                event('jdk.ThreadSleep').with('time', Duration.ofSeconds(1)))
+                event('jdk.ThreadSleep').with('time', Duration.ofMillis(50)))
     }
 
     @EnableEvent(value = 'jdk.FileWrite', threshold = 0L)

--- a/src/test/groovy/dev/morling/jfrunit/JfrSpockSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrSpockSpec.groovy
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2020 - 2021 The JfrUnit authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.jfrunit
+
+import spock.lang.Specification
+
+import java.time.Duration
+
+import static dev.morling.jfrunit.ExpectedEvent.event
+import static dev.morling.jfrunit.JfrEventsAssert.assertThat
+
+@JfrEventTest
+class JfrSpockSpec extends Specification {
+
+    JfrEvents jfrEvents = new JfrEvents()
+
+    @EnableEvent('jdk.GarbageCollection')
+    @EnableEvent('jdk.ThreadSleep')
+    def 'should Have GC And Sleep Events'() {
+        when:
+        System.gc()
+        sleep(1000)
+
+        then:
+        assertThat(jfrEvents).contains(event('jdk.GarbageCollection'))
+        assertThat(jfrEvents).contains(
+                event('jdk.ThreadSleep').with('time', Duration.ofSeconds(1)))
+    }
+
+    @EnableEvent('jdk.ThreadSleep')
+    def 'should Sleep Events when data driven'(int iteration) {
+        given:
+        def sleepTime = iteration * 200
+
+        when:
+        sleep(sleepTime)
+
+        then:
+        jfrEvents.events.filter({it.eventType.name == 'jdk.ThreadSleep' }).count() == 1
+        assertThat(jfrEvents).contains(
+                event('jdk.ThreadSleep').with('time', Duration.ofMillis(sleepTime)))
+
+        where:
+        iteration << [1, 2]
+    }
+}

--- a/src/test/groovy/dev/morling/jfrunit/JfrSpockSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrSpockSpec.groovy
@@ -57,7 +57,7 @@ class JfrSpockSpec extends Specification {
         file << array
 
         then:
-        jfrEvents.events.filter({it.eventType.name == 'jdk.FileWrite' }).count() == 1
+        jfrEvents.events().filter({it.eventType.name == 'jdk.FileWrite' }).count() == 1
         JfrEventsAssert.assertThat(jfrEvents).contains(
                 ExpectedEvent.event('jdk.FileWrite')
                         .with('bytesWritten', bytesWritten)

--- a/src/test/groovy/dev/morling/jfrunit/JfrSpockStepwiseSharedSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/JfrSpockStepwiseSharedSpec.groovy
@@ -43,7 +43,7 @@ class JfrSpockStepwiseSharedSpec extends Specification {
         file << array
 
         then:
-        jfrEvents.events.filter({it.eventType.name == 'jdk.FileWrite' }).count() == 1
+        jfrEvents.events().filter({it.eventType.name == 'jdk.FileWrite' }).count() == 1
         checkFileWrite(jfrEvents, bytesWritten, file)
     }
 
@@ -59,7 +59,7 @@ class JfrSpockStepwiseSharedSpec extends Specification {
         file << array
 
         then:
-        jfrEvents.events.filter({it.eventType.name == 'jdk.FileWrite' }).count() == 2
+        jfrEvents.events().filter({it.eventType.name == 'jdk.FileWrite' }).count() == 2
         checkFileWrite(jfrEvents, bytesWritten, file)
     }
 

--- a/src/test/groovy/dev/morling/jfrunit/ParentSpec.groovy
+++ b/src/test/groovy/dev/morling/jfrunit/ParentSpec.groovy
@@ -1,0 +1,26 @@
+/**
+ *  Copyright 2020 - 2021 The JfrUnit authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.jfrunit
+
+import spock.lang.Specification
+
+@JfrEventTest
+abstract class ParentSpec extends Specification {
+
+    JfrEvents jfrEvents = new JfrEvents()
+
+
+}

--- a/src/test/java/dev/morling/jfrunit/JfrUnitTest.java
+++ b/src/test/java/dev/morling/jfrunit/JfrUnitTest.java
@@ -35,7 +35,7 @@ public class JfrUnitTest {
     @DisplayName("Should have Gc and Sleep events recorded when explicitly enabled individually with @EnableEvent")
     public void shouldHaveGcAndSleepEvents() throws Exception {
         System.gc();
-        Thread.sleep(1000);
+        Thread.sleep(50);
 
         jfrEvents.awaitEvents();
 
@@ -43,7 +43,7 @@ public class JfrUnitTest {
         assertThat(jfrEvents).contains(
                 event("jdk.GarbageCollection").with("cause", "System.gc()"));
         assertThat(jfrEvents).contains(
-                event("jdk.ThreadSleep").with("time", Duration.ofSeconds(1)));
+                event("jdk.ThreadSleep").with("time", Duration.ofMillis(50)));
 
         assertThat(jfrEvents.filter(event("jdk.GarbageCollection"))).hasSize(1);
     }
@@ -53,7 +53,7 @@ public class JfrUnitTest {
     @DisplayName("Should have Gc and Sleep events recorded when enabled with configuration 'profile'")
     public void shouldHaveGcAndSleepEventsWithDefaultConfiguration() throws Exception {
         System.gc();
-        Thread.sleep(1000);
+        Thread.sleep(50);
 
         jfrEvents.awaitEvents();
 
@@ -61,7 +61,7 @@ public class JfrUnitTest {
         assertThat(jfrEvents).contains(
                 event("jdk.GarbageCollection").with("cause", "System.gc()"));
         assertThat(jfrEvents).contains(
-                event("jdk.ThreadSleep").with("time", Duration.ofSeconds(1)));
+                event("jdk.ThreadSleep").with("time", Duration.ofMillis(50)));
 
         assertThat(jfrEvents.filter(
                 event("jdk.GarbageCollection").with("cause", "System.gc()")))
@@ -72,7 +72,7 @@ public class JfrUnitTest {
     @EnableEvent("jdk.ThreadSleep")
     @DisplayName("Should have StackTrace captured for StackTrace-Enabled Events by default with StackTrace policy Default")
     public void captureTracesWhenEnabledWithPolicyDefault() throws Exception {
-        Thread.sleep(1000);
+        Thread.sleep(50);
 
         jfrEvents.awaitEvents();
 
@@ -95,7 +95,7 @@ public class JfrUnitTest {
     @EnableEvent(value = "jdk.ThreadSleep", stackTrace = EnableEvent.StacktracePolicy.INCLUDED)
     @DisplayName("Should have StackTrace captured irrespective of Event StackTrace Configuration(Enabled) with StackTrace policy Included")
     public void captureTraceWhenEnabledWithStackTracePolicyIncluded() throws Exception {
-        Thread.sleep(1000);
+        Thread.sleep(50);
 
         jfrEvents.awaitEvents();
 
@@ -118,7 +118,7 @@ public class JfrUnitTest {
     @EnableEvent(value = "jdk.ThreadSleep", stackTrace = EnableEvent.StacktracePolicy.EXCLUDED)
     @DisplayName("Should not have StackTrace captured irrespective of Event StackTrace Configuration(Enabled) with StackTrace policy Excluded")
     public void doNotCaptureTraceWhenEnabledWithStackTracePolicyExcluded() throws Exception {
-        Thread.sleep(1000);
+        Thread.sleep(50);
 
         jfrEvents.awaitEvents();
 

--- a/src/test/java/dev/morling/jfrunit/TestTLABRelated.java
+++ b/src/test/java/dev/morling/jfrunit/TestTLABRelated.java
@@ -39,7 +39,6 @@ public class TestTLABRelated {
     @EnableEvent("jdk.ObjectAllocationInNewTLAB")
     public void testSlowAllocation() throws InterruptedException {
         System.gc();
-        Thread.sleep(1000);
         for (int i = 0; i < 512; ++i) {
             tmp = new byte[OBJECT_SIZE - BYTE_ARRAY_OVERHEAD];
         }

--- a/src/test/java/dev/morling/jfrunit/ThreadSleepTest.java
+++ b/src/test/java/dev/morling/jfrunit/ThreadSleepTest.java
@@ -63,10 +63,10 @@ public class ThreadSleepTest {
 
 
     @Test
-    @EnableEvent(value = "jdk.ThreadSleep", threshold = 500)
+    @EnableEvent(value = "jdk.ThreadSleep", threshold = 100)
     public void testWithThreshold() throws Exception {
         Thread.sleep(10);
-        Thread.sleep(1000);
+        Thread.sleep(200);
 
         jfrEvents.awaitEvents();
 


### PR DESCRIPTION
Hopefully this could do the job.
- `awaitEvents()` is called on stream access. Not sure if there is a better way, but it seems that's what one typically do anyway even in JUnit. Perhaps there is a room for optimization.
- `JfrEvents` instance is cleared after each test unless marked as `@Shared`.