### PR TITLE
Quarkus: Collect JfrUnit fields from the complete inheritance path

### DIFF
--- a/src/main/java/dev/morling/jfrunit/JfrUnitQuarkusLifecycleCallback.java
+++ b/src/main/java/dev/morling/jfrunit/JfrUnitQuarkusLifecycleCallback.java
@@ -15,6 +15,7 @@
  */
 package dev.morling.jfrunit;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
 import io.quarkus.test.junit.callback.QuarkusTestAfterEachCallback;
 import io.quarkus.test.junit.callback.QuarkusTestBeforeEachCallback;
 import io.quarkus.test.junit.callback.QuarkusTestMethodContext;
+import java.util.stream.Stream;
 
 public class JfrUnitQuarkusLifecycleCallback implements QuarkusTestBeforeEachCallback, QuarkusTestAfterEachCallback {
 
@@ -63,7 +65,7 @@ public class JfrUnitQuarkusLifecycleCallback implements QuarkusTestBeforeEachCal
     }
 
     private List<JfrEvents> getJfrEvents(Object instance) {
-        return Arrays.stream(instance.getClass().getDeclaredFields())
+        return getAllFields(instance.getClass())
             .filter(f -> f.getType() == JfrEvents.class)
             .map(f -> {
                 try {
@@ -74,5 +76,17 @@ public class JfrUnitQuarkusLifecycleCallback implements QuarkusTestBeforeEachCal
                 }
             })
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Gets all fields declared anywhere on the inheritance path between the given class and {@link Object}.
+     *
+     * This is necessary because Quarkus may implicitly subclass a test class with a proxy class.
+     */
+    private static Stream<Field> getAllFields(Class<?> c) {
+        Class<?> superclass = c.getSuperclass();
+        return Stream.concat(
+            Arrays.stream(c.getDeclaredFields()),
+            superclass == null ? Stream.empty() : getAllFields(superclass));
     }
 }

--- a/src/test/java/dev/morling/jfrunit/TestSubclassTest.java
+++ b/src/test/java/dev/morling/jfrunit/TestSubclassTest.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2020 - 2021 The JfrUnit authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.jfrunit;
+
+import static dev.morling.jfrunit.ExpectedEvent.event;
+import static dev.morling.jfrunit.JfrEventsAssert.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+class TestSuperclass {
+    public JfrEvents jfrEvents = new JfrEvents();
+}
+
+@JfrEventTest
+public class TestSubclassTest extends TestSuperclass {
+
+    @Test
+    @EnableEvent("jfrunit.test.StackTraceDisabledSampleEvent")
+    @DisplayName(
+        "Can detect a submitted event when instantiated as a subclass of the test class holding the JfrEvents field")
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void simple() {
+        StackTraceDisabledSampleEvent event = new StackTraceDisabledSampleEvent();
+        event.commit();
+
+        jfrEvents.awaitEvents();
+
+        assertThat(jfrEvents).contains(event("jfrunit.test.StackTraceDisabledSampleEvent"));
+    }
+}


### PR DESCRIPTION
`JfrUnitQuarkusLifecycleCallback#getJfrEvents` would not pick up `JfrUnit` fields declared in a test if Quarkus subclassed the test class with a proxy class.  This patch fixes that.