### PR TITLE
Dump recordings into temporary directory if necessary

### DIFF
--- a/src/main/java/dev/morling/jfrunit/JfrEvents.java
+++ b/src/main/java/dev/morling/jfrunit/JfrEvents.java
@@ -92,7 +92,7 @@ public class JfrEvents {
                 dumpDir = Files.createDirectories(Path.of(testSourceUri).getParent().resolve("jfrunit"));
             } catch (FileSystemNotFoundException e) {
                 dumpDir = Files.createTempDirectory(null);
-                LOGGER.log(Level.DEBUG, "'" + testSourceUri.getScheme() + "' is not a valid file system, dumping recording to a temporary location.");
+                LOGGER.log(Level.WARN, "'" + testSourceUri.getScheme() + "' is not a valid file system, dumping recording to a temporary location.");
             }
 
             Path recordingPath = dumpDir.resolve(testMethod.getDeclaringClass().getName() + "-" + testMethod.getName() + ".jfr");


### PR DESCRIPTION
In Quarkus (tested version: 2.0.0.Alpha2), the path to the test source file can resolve to a URI with a scheme of “quarkus”, which does not designate a real file system path.  In this case, `Path#of` throws a `FileSystemNotFoundException`, which we now catch and use to fall back to a directory created with `Files#createTempDirectory`.