### PR TITLE
Jitpack: Update to JDK 16.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 before_install:
   - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
-  - source install-jdk.sh --feature 14
+  - source install-jdk.sh --feature 16
   - jshell --version


### PR DESCRIPTION
Jitpack builds are currently failing:

    Detected JDK Version: 14.0.2 is not in the allowed range [16.0,).

This should get that particular error out of the way.
